### PR TITLE
Removed empty constructor in Position.java

### DIFF
--- a/src/main/java/com/github/goober/coordinatetransformation/Position.java
+++ b/src/main/java/com/github/goober/coordinatetransformation/Position.java
@@ -33,9 +33,6 @@ public abstract class Position {
     public Position(Grid format) {
         gridFormat = format;
     }
-    public Position() {
-        
-    }
 
     public double getLatitude() {
         return this.latitude;


### PR DESCRIPTION
Removed empty unused constructor in `Position.java`, which would just cause the `gridFormat` variable to be `null` if used wrong outside of the files included in the library.